### PR TITLE
Add windows build

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -1,0 +1,111 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: win
+  pool:
+    vmImage: vs2017-win2016
+  timeoutInMinutes: 360
+  strategy:
+    maxParallel: 4
+    matrix:
+      win_c_compilervs2015python3.6:
+        CONFIG: win_c_compilervs2015python3.6
+        CONDA_BLD_PATH: D:\\bld\\
+        UPLOAD_PACKAGES: True
+      win_c_compilervs2015python3.7:
+        CONFIG: win_c_compilervs2015python3.7
+        CONDA_BLD_PATH: D:\\bld\\
+        UPLOAD_PACKAGES: True
+      win_c_compilervs2015python3.8:
+        CONFIG: win_c_compilervs2015python3.8
+        CONDA_BLD_PATH: D:\\bld\\
+        UPLOAD_PACKAGES: True
+  steps:
+    # TODO: Fast finish on azure pipelines?
+    - script: |
+        ECHO ON
+        
+
+    - script: |
+        choco install vcpython27 -fdv -y --debug
+      condition: contains(variables['CONFIG'], 'vs2008')
+      displayName: Install vcpython27.msi (if needed)
+
+    # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
+    # - script: rmdir C:\cygwin /s /q
+    #   continueOnError: true
+
+    - powershell: |
+        Set-PSDebug -Trace 1
+
+        $batchcontent = @"
+        ECHO ON
+        SET vcpython=C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0
+
+        DIR "%vcpython%"
+
+        CALL "%vcpython%\vcvarsall.bat" %*
+        "@
+
+        $batchDir = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0\VC"
+        $batchPath = "$batchDir" + "\vcvarsall.bat"
+        New-Item -Path $batchPath -ItemType "file" -Force
+
+        Set-Content -Value $batchcontent -Path $batchPath
+
+        Get-ChildItem -Path $batchDir
+
+        Get-ChildItem -Path ($batchDir + '\..')
+
+      condition: contains(variables['CONFIG'], 'vs2008')
+      displayName: Patch vs2008 (if needed)
+
+    - task: CondaEnvironment@1
+      inputs:
+        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=2' # Optional
+        installOptions: "-c conda-forge"
+        updateConda: false
+      displayName: Install conda-build and activate environment
+
+    - script: set PYTHONUNBUFFERED=1
+
+    # Configure the VM
+    - script: setup_conda_rc .\ .\recipe .\.ci_support\%CONFIG%.yaml
+
+    # Configure the VM.
+    - script: |
+        set "CI=azure"
+        run_conda_forge_build_setup
+      displayName: conda-forge build setup
+    
+
+    - script: |
+        rmdir C:\strawberry /s /q
+      continueOnError: true
+      displayName: remove strawberryperl
+
+    # Special cased version setting some more things!
+    - script: |
+        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
+      displayName: Build recipe (vs2008)
+      env:
+        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
+        PYTHONUNBUFFERED: 1
+      condition: contains(variables['CONFIG'], 'vs2008')
+
+    - script: |
+        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
+      displayName: Build recipe
+      env:
+        PYTHONUNBUFFERED: 1
+      condition: not(contains(variables['CONFIG'], 'vs2008'))
+
+    - script: |
+        set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
+        upload_package .\ .\recipe .ci_support\%CONFIG%.yaml
+      displayName: Upload package
+      env:
+        BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+      condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/.ci_support/win_c_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015python3.6.yaml
@@ -1,0 +1,17 @@
+c_compiler:
+- vs2015
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'
+zip_keys:
+- - python
+  - c_compiler

--- a/.ci_support/win_c_compilervs2015python3.7.yaml
+++ b/.ci_support/win_c_compilervs2015python3.7.yaml
@@ -1,0 +1,17 @@
+c_compiler:
+- vs2015
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'
+zip_keys:
+- - python
+  - c_compiler

--- a/.ci_support/win_c_compilervs2015python3.8.yaml
+++ b/.ci_support/win_c_compilervs2015python3.8.yaml
@@ -1,0 +1,17 @@
+c_compiler:
+- vs2015
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.8'
+zip_keys:
+- - python
+  - c_compiler

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kmuehlbauer @kynan @ocefpaf @pelson
+* @dtip @kmuehlbauer @kynan @ocefpaf @pelson

--- a/README.md
+++ b/README.md
@@ -70,16 +70,31 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-eccodes-feedstock?branchName=master&jobName=osx&configuration=osx_python3.8" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>win_c_compilervs2015python3.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5050&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-eccodes-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015python3.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_c_compilervs2015python3.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5050&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-eccodes-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015python3.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_c_compilervs2015python3.8</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5050&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-eccodes-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015python3.8" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>
       </details>
-    </td>
-  </tr>
-  <tr>
-    <td>Windows</td>
-    <td>
-      <img src="https://img.shields.io/badge/Windows-disabled-lightgrey.svg" alt="Windows disabled">
     </td>
   </tr>
   <tr>
@@ -182,6 +197,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@dtip](https://github.com/dtip/)
 * [@kmuehlbauer](https://github.com/kmuehlbauer/)
 * [@kynan](https://github.com/kynan/)
 * [@ocefpaf](https://github.com/ocefpaf/)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,3 +5,4 @@
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
   - template: ./.azure-pipelines/azure-pipelines-osx.yml
+  - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,1 @@
+%PYTHON% -m pip install . -vv --no-deps

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,3 +49,4 @@ extra:
     - pelson
     - ocefpaf
     - kynan
+    - dtip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: 45ec0383a831054a9e775c5fde706ddd21ad0a6177df8f6a8cbd5ab0f80fdf76
 
 build:
-  number: 0
-  skip: True  # [win or py2k]
+  number: 1
+  skip: True  # [py2k]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,12 +20,12 @@ requirements:
     - python
     - pip
     - numpy
-    - cffi
+    - cffi  # [not win]
     - eccodes ={{ eccodes_version }}
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - cffi
+    - cffi  # [not win]
     - attrs
     - eccodes ={{ eccodes_version }}
 
@@ -33,7 +33,7 @@ test:
   imports:
     - eccodes
     - gribapi
-    - gribapi._bindings
+    - gribapi._bindings  # [not win]
 
 about:
   home: https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,12 +20,12 @@ requirements:
     - python
     - pip
     - numpy
-    - cffi  # [not win]
+    - cffi
     - eccodes ={{ eccodes_version }}
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - cffi  # [not win]
+    - cffi
     - attrs
     - eccodes ={{ eccodes_version }}
 


### PR DESCRIPTION
Quick experiment to see if we can get an Windows build for python-eccodes.

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
