### PR TITLE
version 1.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2021.05.1" %}
-{% set eccodes_version = "2.20.0" %}
+{% set version = "1.4.0" %}
+{% set eccodes_version = "2.23.0" %}
 
 package:
   name: python-eccodes
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/ecmwf/eccodes-python/archive/{{ version }}.tar.gz
-  sha256: 3ef3313148609b42f2497d98cedacc9614249b53a954ad78bb0d3c4bcc4a058a
+  sha256: 625055bc9efba37d3564562c17779814fa3cc9f6e5ebe0115bf3d78edcc7d503
 
 build:
   number: 0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is part of a larger piece of work to remove all the badly tagged versions (e.g. 2021.05.0) and replace them with the 'proper' versions, e.g. 1.4.0. I will try to create a 1.4.0 version and mark all the others on anaconda as broken. Existing users will still have the problem that if they have a version 2021.* installed then most likely their conda systems will not see the new versions as being newer and will not update to them. But since we no longer push the 'date-like' tags, no newer versions will become available to them anyway (we now only push the 'proper' tags). At least this way we have proper versioning and conda-forge should detect new versions when they are released.